### PR TITLE
Make binary statically linked instead of dynamically

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,6 +12,7 @@ stages:
   - mkdir -p .cache
   - export GOPATH="$CI_PROJECT_DIR/.cache"
   - export GOCACHE="$CI_PROJECT_DIR/.cache/build"
+  - export CGO_ENABLED=0
   script:
   - go build -o mautrix-wsproxy
   artifacts:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1-alpine3.13 AS builder
 
 COPY . /build
 WORKDIR /build
-RUN go build -o /usr/bin/mautrix-wsproxy
+RUN CGO_ENABLED=0 go build -o /usr/bin/mautrix-wsproxy
 
 FROM scratch
 


### PR DESCRIPTION
Hey,
I'm not really experienced with golang, so take that pull request with a grain of salt.
I noticed that the docker image didn't work and searched for a solution. The problem appears to be that the binary isn't statically linked and since you use 'FROM scratch' as a base for the image, the required libraries aren't there.
After googling a bit, I found this [site](https://www.arp242.net/static-go.html), which recommended to set CGO_ENABLED=0.
After building the image locally myself with that, the image seems to work.
